### PR TITLE
Fix stdin input on Windows

### DIFF
--- a/src/cli/program.js
+++ b/src/cli/program.js
@@ -36,7 +36,7 @@ module.exports = function createProgram() {
       }
 
       const { context: dockerContext, output } = cmd
-      const absoluteDockerfilePath = file.startsWith("/")
+      const absoluteDockerfilePath = path.isAbsolute(file)
         ? file
         : path.join(dockerContext, file)
 


### PR DESCRIPTION
The startsWith('/') heuristic does not work in windows. Instead, rely on the portable path.isAbsolute node call.