### PR TITLE
fix: build commands disappeared

### DIFF
--- a/src/lib/parseDockerfile.js
+++ b/src/lib/parseDockerfile.js
@@ -10,75 +10,103 @@ module.exports = function parseDockerfile(content, options = {}) {
     ...parseOptions,
   })
   const lines = content.split(/\r?\n/)
+
+  // Get 0-based start line index from instruction metadata
+  // (prefer header fields over lineno)
+  const getStartLineIndex = (instruction) => {
+    for (const key of ["lineno", "startLine", "startline", "line"]) {
+      if (instruction[key]) return instruction[key] - 1
+    }
+    return 0
+  }
+
+  // Get raw text from lines[start..end]
+  const getRaw = (start, end) => lines.slice(start, end + 1).join("\n")
+
+  // Check if line starts with instruction
+  const startsWithInstruction = (line, name) => {
+    if (!name) return false
+    const token = (line || "").replace(/^\s+/, "").split(/\s+/, 1)[0]
+    return token.toUpperCase() === String(name).toUpperCase()
+  }
+
+  // Extract here-doc delimiter token from args
+  const getHereDocDelimiter = (args) => {
+    const text = String(args ?? "")
+    const m = text.match(/<<-?\s*(['"]?)([A-Za-z0-9_]+)\1/)
+    return m ? m[2] : null
+  }
+
+  // Find the closing line of a here-doc block
+  const findHereDocClose = (startIndex, delimiter) => {
+    for (let j = startIndex + 1; j < instructions.length; j++) {
+      const seg = instructions[j]
+      const segRaw = seg.raw != null ? String(seg.raw).trim() : ""
+      if (seg.name === delimiter || segRaw === delimiter) {
+        return { closeIndex: j, closeLineIdx: getStartLineIndex(seg) }
+      }
+    }
+    return null
+  }
+
+  const results = []
   for (let i = 0; i < instructions.length; i++) {
     const instruction = instructions[i]
+    const name = instruction.name.toUpperCase()
 
-    // Determine start line (0-based) from available fields; fallback to 0
-    const startIdx =
-      (instruction.lineno && instruction.lineno - 1) ||
-      (instruction.startLine && instruction.startLine - 1) ||
-      (instruction.startline && instruction.startline - 1) ||
-      (instruction.line && instruction.line - 1) ||
-      0
-
-    // Determine next instruction start (for fallback end bound)
-    const next = instructions[i + 1]
-    const nextStartIdx = next
-      ? (next.lineno && next.lineno - 1) ||
-        (next.startLine && next.startLine - 1) ||
-        (next.startline && next.startline - 1) ||
-        (next.line && next.line - 1) ||
-        lines.length
-      : lines.length
-
-    // End index: prefer docker-file-parser's lineno (last line of instruction), else before next instruction
-    const endIdx =
-      instruction.lineno && Number.isInteger(instruction.lineno)
-        ? instruction.lineno - 1
-        : Math.max(startIdx, nextStartIdx - 1)
-
-    // Recover the true start by scanning upward from endIdx until the header line (instruction keyword) is found
-    const headerToken = (line) => {
-      if (!line) return null
-      const m = line.match(/^\s*([A-Za-z]+)/)
-      return m ? m[1] : null
-    }
-    const startsWithName = (line, name) => {
-      if (!name) return false
-      const tok = headerToken(line)
-      return tok ? tok.toUpperCase() === String(name).toUpperCase() : false
+    if (
+      name === "COMMENT" &&
+      removeSyntaxComments &&
+      syntaxCommentRegex.test(instruction.args)
+    ) {
+      // Remove syntax comment
+      continue
     }
 
-    let startIdxScan = endIdx
-    if (instruction.name !== "COMMENT") {
-      while (
-        startIdxScan >= 0 &&
-        !startsWithName(lines[startIdxScan] || "", instruction.name)
-      ) {
-        startIdxScan--
-      }
-      if (startIdxScan < 0) {
-        startIdxScan = startIdx
-      }
-    }
-
-    const defaultRaw = lines.slice(startIdxScan, endIdx + 1).join("\n")
-
-    if (instruction.name === "COMMENT") {
-      if (removeSyntaxComments && syntaxCommentRegex.test(instruction.args)) {
-        instruction.raw = ""
-      } else {
-        // Preserve exact original comment formatting (including indentation)
-        instruction.raw = defaultRaw
-      }
-    } else if (instruction.name === "FROM") {
+    if (name === "FROM") {
       // Normalize "AS" casing but keep args semantics
-      instruction.args = instruction.args.replace(/(\s+)as(\s+)/gi, "$1AS$2")
+      if (typeof instruction.args === "string") {
+        instruction.args = instruction.args.replace(/(\s+)as(\s+)/g, "$1AS$2")
+      }
       instruction.raw = generateRawInstruction(instruction)
-    } else {
-      // Preserve exact original formatting for all other instructions (e.g., RUN with continuations/indentation)
-      instruction.raw = defaultRaw
     }
+
+    // Determine start line (0-based), end line from available fields; fallback to 0
+    let startIdx = getStartLineIndex(instruction)
+    const endIdx = startIdx // Default to the same line as the start line
+
+    // Find the corresponding start line that really starts with the instruction
+    if (name !== "COMMENT") {
+      while (startIdx > 0 && !startsWithInstruction(lines[startIdx], name)) {
+        startIdx--
+      }
+    }
+
+    // Merge multi-line instructions (RUN, ARG, ENV, etc.)
+    let closeIndex = i
+    let closeLineIdx = endIdx
+
+    // Check for here-doc in RUN instructions
+    if (name === "RUN") {
+      const delimiter = getHereDocDelimiter(instruction.args)
+      if (delimiter) {
+        const close = findHereDocClose(i, delimiter)
+        if (close) {
+          closeIndex = close.closeIndex
+          closeLineIdx = close.closeLineIdx
+        }
+      }
+    }
+
+    // Update instruction metadata
+    instruction.lineno = startIdx + 1
+    instruction.raw = getRaw(startIdx, closeLineIdx)
+
+    // Skip merged child instructions (i+1 ... closeIndex)
+    if (closeIndex > i) i = closeIndex
+
+    results.push(instruction)
   }
-  return instructions
+
+  return results
 }

--- a/test/__snapshots__/issues/preserve-environment-variables.expected.dockerfile
+++ b/test/__snapshots__/issues/preserve-environment-variables.expected.dockerfile
@@ -1,0 +1,9 @@
+# See: https://codeberg.org/devthefuture/dockerfile-x/issues/28
+FROM debian:latest
+ARG  DEBUG
+RUN <<'EOF'
+DEBIAN_FRONTEND=noninteractive \
+DEBCONF_NOWARNINGS=yes \
+APT_LISTCHANGES_FRONTEND=none \
+apt-get update
+EOF

--- a/test/__snapshots__/issues/preserve-instructions.expected.dockerfile
+++ b/test/__snapshots__/issues/preserve-instructions.expected.dockerfile
@@ -1,0 +1,30 @@
+# See: https://codeberg.org/devthefuture/dockerfile-x/issues/27
+FROM debian:latest
+ARG  DEBUG
+RUN <<'EOF'
+[ -z "$DEBUG" ] || set -ex && set -e
+if command -v something; then
+    something \
+        --arg1 test1 \
+        --arg2 test2
+else
+    echo "something not found"
+fi
+EOF
+RUN [ -x "/hogehoge" ] \
+    && echo "OK" \
+    || true
+ARG DEBUG1
+ENV DEBUG2=1 DEBUG3=2 DEBUG4=3 \
+    TEST1=1 TEST2=2 TEST3=3 \
+    TIMEZONE=Asia/Tokyo
+RUN <<TEST
+[ -z "$DEBUG" ] || set -ex && set -e
+if command -v something; then
+    something \
+        --arg1 test1 \
+        --arg2 test2
+else
+    echo "something not found"
+fi
+TEST

--- a/test/fixs.js
+++ b/test/fixs.js
@@ -16,4 +16,10 @@ describe("issues", () => {
   it("include-target", async () => {
     await testFixture("issue1")
   })
+  it("preserve-instructions", async () => {
+    await testFixture("issue27")
+  })
+  it("preserve-environment-variables", async () => {
+    await testFixture("issue28")
+  })
 })

--- a/test/fixtures/issue27.dockerfile
+++ b/test/fixtures/issue27.dockerfile
@@ -1,0 +1,36 @@
+# syntax=devthefuture/dockerfile-x
+# See: https://codeberg.org/devthefuture/dockerfile-x/issues/27
+FROM debian:latest
+ARG  DEBUG
+
+RUN <<'EOF'
+[ -z "$DEBUG" ] || set -ex && set -e
+if command -v something; then
+    something \
+        --arg1 test1 \
+        --arg2 test2
+else
+    echo "something not found"
+fi
+EOF
+
+RUN [ -x "/hogehoge" ] \
+    && echo "OK" \
+    || true
+
+ARG DEBUG1
+
+ENV DEBUG2=1 DEBUG3=2 DEBUG4=3 \
+    TEST1=1 TEST2=2 TEST3=3 \
+    TIMEZONE=Asia/Tokyo
+
+RUN <<TEST
+[ -z "$DEBUG" ] || set -ex && set -e
+if command -v something; then
+    something \
+        --arg1 test1 \
+        --arg2 test2
+else
+    echo "something not found"
+fi
+TEST

--- a/test/fixtures/issue28.dockerfile
+++ b/test/fixtures/issue28.dockerfile
@@ -1,0 +1,11 @@
+# syntax=devthefuture/dockerfile-x
+# See: https://codeberg.org/devthefuture/dockerfile-x/issues/28
+FROM debian:latest
+ARG  DEBUG
+
+RUN <<'EOF'
+DEBIAN_FRONTEND=noninteractive \
+DEBCONF_NOWARNINGS=yes \
+APT_LISTCHANGES_FRONTEND=none \
+apt-get update
+EOF


### PR DESCRIPTION
This pull request improves preserving the original build instructions in `*.dockerfile` files. It also adds new fixtures for issues below:
- https://codeberg.org/devthefuture/dockerfile-x/issues/27
- https://codeberg.org/devthefuture/dockerfile-x/issues/28