### PR TITLE
feat: include args envs labels from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ However, if you're working with Docker versions as old as 18.09, you can still e
 
 ## Features:
 - [INCLUDE](#include): Incorporate content as is from other Dockerfiles or snippets.
+- [INCLUDE_ARGS](#include_args): Converts a `.env` file into Dockerfile `ARG` instructions.
+- [INCLUDE_ENVS](#include_envs): Converts a `.env` file into Dockerfile `ENV` instructions.
+- [INCLUDE_LABELS](#include_labels): Converts a `.env` file into Dockerfile `LABEL` instructions.
 - [FROM](#from):
   - [FROM with Relative Paths](#from-with-relative-paths): Use other Dockerfiles as a base using relative paths.
   - [FROM with Stages](#from-with-stages): Reference specific stages from other Dockerfiles.
@@ -112,6 +115,75 @@ Easily include content from another Dockerfile or snippet, ensuring straightforw
 ```Dockerfile
 # Include another Dockerfile's content
 INCLUDE ./path/to/another/dockerfile
+```
+
+### INCLUDE_ARGS
+
+Converts key-value pairs from a `.env` file into Dockerfile `ARG` instructions.
+Use this to expose build-time variables without hardcoding them into the Dockerfile.
+
+```text
+# custom-args.env
+NODE_VERSION=20.11.1
+PNPM_VERSION=9.1.0
+```
+
+```Dockerfile
+# Include key-value pairs from file
+INCLUDE_ARGS ./path/to/custom-args.env
+```
+
+This expands to:
+```Dockerfile
+ARG NODE_VERSION="20.11.1"
+ARG PNPM_VERSION="9.1.0"
+```
+
+**Note:** Values can be overridden at build time with `--build-arg` if desired.
+
+### INCLUDE_ENVS
+
+Converts key-value pairs from a `.env` file into Dockerfile `ENV` instructions.
+Ideal for runtime configuration baked into the image.
+
+```text
+# custom-envvars.env
+NODE_ENV=production
+APP_PORT=8080
+```
+
+```Dockerfile
+# Include key-value pairs from file
+INCLUDE_ENVS ./path/to/custom-envvars.env
+```
+
+This expands to:
+```Dockerfile
+ENV NODE_ENV="production"
+ENV APP_PORT="8080"
+```
+
+### INCLUDE_LABELS
+Converts key-value pairs from a `.env` file into Dockerfile `LABEL` instructions.
+Useful for image metadata (e.g., authorship, version, VCS refs).
+
+```text
+# custom-labels.env
+org.opencontainers.image.title=myapp
+org.opencontainers.image.version=1.2.3
+org.opencontainers.image.revision=abc1234
+```
+
+```Dockerfile
+# Include key-value pairs from file
+INCLUDE_LABELS ./path/to/custom-labels.env
+```
+
+This expands to:
+```Dockerfile
+LABEL org.opencontainers.image.title="myapp" 
+LABEL org.opencontainers.image.version="1.2.3" 
+LABEL org.opencontainers.image.revision="abc1234"
 ```
 
 ### FROM

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "@grpc/proto-loader": "^0.7.9",
     "axios": "^1.5.0",
     "commander": "^11.0.0",
-    "docker-file-parser": "^1.0.7"
+    "docker-file-parser": "^1.0.7",
+    "dotenv": "^17.2.1"
   },
   "repository": "https://codeberg.org/devthefuture/dockerfile-x",
   "devDependencies": {

--- a/src/core/loadEnvFileAndPrefix.js
+++ b/src/core/loadEnvFileAndPrefix.js
@@ -1,0 +1,55 @@
+const path = require("path")
+const fs = require("fs/promises")
+const dotenv = require("dotenv")
+const checkFileExists = require("../utils/checkFileExists")
+
+const DEFAULT_EXTENSION = ".env"
+
+async function resolveEnvFilePath(filePath) {
+  if (await checkFileExists(filePath)) return filePath
+
+  // try adding extension and read again
+  if (path.extname(filePath) !== DEFAULT_EXTENSION) {
+    const withExt = `${filePath}${DEFAULT_EXTENSION}`
+    if (await checkFileExists(withExt)) return withExt
+  }
+
+  return null
+}
+
+function formatDockerInstruction(prefix, key, value) {
+  const cleanKey = key.replace(/[^A-Z0-9_]/gi, "")
+  const cleanValue = String(value || "")
+    .replace(/\\/g, "\\\\")
+    .replace(/\$/g, "\\$")
+    .replace(/"/g, '\\"')
+    .replace(/`/g, "\\`")
+    .replace(/\r?\n/g, "\\n\\\n")
+  return `${prefix}${cleanKey}="${cleanValue}"`
+}
+
+module.exports = async function loadEnvFileAndPrefix(
+  dockerContext,
+  filePath,
+  prefix = "",
+) {
+  const relativeFilePath = path.relative(dockerContext, filePath)
+  const resolvedPath = await resolveEnvFilePath(filePath)
+
+  if (!resolvedPath) {
+    process.stdout.write(
+      JSON.stringify({
+        error: "missing-file",
+        filename: relativeFilePath,
+      }),
+    )
+    process.exit(2)
+  }
+
+  const envContent = await fs.readFile(resolvedPath, "utf-8")
+  const envVars = dotenv.parse(envContent) || {}
+
+  return Object.entries(envVars)
+    .map(([key, value]) => formatDockerInstruction(prefix, key, value))
+    .join("\n")
+}

--- a/src/instruction/index.js
+++ b/src/instruction/index.js
@@ -8,5 +8,8 @@ module.exports = (processingContext) => ({
   COPY: fromParam(processingContext),
   ADD: fromParam(processingContext),
   INCLUDE: include(processingContext),
+  INCLUDE_ARGS: include(processingContext, "ARG"),
+  INCLUDE_ENVS: include(processingContext, "ENV"),
+  INCLUDE_LABELS: include(processingContext, "LABEL"),
   _DEFAULT: _default(processingContext),
 })

--- a/test/__snapshots__/INCLUDE/include_envvars.expected.dockerfile
+++ b/test/__snapshots__/INCLUDE/include_envvars.expected.dockerfile
@@ -1,0 +1,91 @@
+# See https://codeberg.org/devthefuture/dockerfile-x/issues/3
+FROM busybox
+# include custom args from external file
+# DOCKERFILE-X:START file="./inc/custom-args.env" includedBy="issue3.dockerfile" includeType="include"
+ARG BASIC="basic"
+ARG AFTER_LINE="after_line"
+ARG EMPTY=""
+ARG SINGLE_QUOTES="single_quotes"
+ARG SINGLE_QUOTES_SPACED="    single quotes    "
+ARG DOUBLE_QUOTES="double_quotes"
+ARG DOUBLE_QUOTES_SPACED="    double quotes    "
+ARG EXPAND_NEWLINES="expand\n\
+new\n\
+lines"
+ARG DONT_EXPAND_UNQUOTED="dontexpand\\nnewlines"
+ARG DONT_EXPAND_SQUOTED="dontexpand\\nnewlines"
+ARG EQUAL_SIGNS="equals=="
+ARG RETAIN_INNER_QUOTES="{\"foo\": \"bar\"}"
+ARG RETAIN_INNER_QUOTES_AS_STRING="{\"foo\": \"bar\"}"
+ARG TRIM_SPACE_FROM_UNQUOTED="some spaced out string"
+ARG USERNAME="therealnerdybeast@example.tld"
+ARG SPACED_KEY="parsed"
+ARG MULTI_DOUBLE_QUOTED="THIS\n\
+IS\n\
+A\n\
+MULTILINE\n\
+STRING"
+ARG MULTI_SINGLE_QUOTED="THIS\n\
+IS\n\
+A\n\
+MULTILINE\n\
+STRING"
+ARG MULTI_BACKTICKED="THIS\n\
+IS\n\
+A\n\
+\"MULTILINE'S\"\n\
+STRING"
+ARG MULTI_PEM_DOUBLE_QUOTED="-----BEGIN PUBLIC KEY-----\n\
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnNl1tL3QjKp3DZWM0T3u\n\
+LgGJQwu9WqyzHKZ6WIA5T+7zPjO1L8l3S8k8YzBrfH4mqWOD1GBI8Yjq2L1ac3Y/\n\
+bTdfHN8CmQr2iDJC0C6zY8YV93oZB3x0zC/LPbRYpF8f6OqX1lZj5vo2zJZy4fI/\n\
+kKcI5jHYc8VJq+KCuRZrvn+3V+KuL9tF9v8ZgjF2PZbU+LsCy5Yqg1M8f5Jp5f6V\n\
+u4QuUoobAgMBAAE=\n\
+-----END PUBLIC KEY-----"
+# DOCKERFILE-X:END file="./inc/custom-args.env" includedBy="issue3.dockerfile" includeType="include"
+# include custom envvars from external file
+# DOCKERFILE-X:START file="./inc/custom-envs.env" includedBy="issue3.dockerfile" includeType="include"
+ENV BASIC="basic"
+ENV AFTER_LINE="after_line"
+ENV EMPTY=""
+ENV EMPTY_SINGLE_QUOTES=""
+ENV EMPTY_DOUBLE_QUOTES=""
+ENV EMPTY_BACKTICKS=""
+ENV SINGLE_QUOTES="single_quotes"
+ENV SINGLE_QUOTES_SPACED="    single quotes    "
+ENV DOUBLE_QUOTES="double_quotes"
+ENV DOUBLE_QUOTES_SPACED="    double quotes    "
+ENV DOUBLE_QUOTES_INSIDE_SINGLE="double \"quotes\" work inside single quotes"
+ENV DOUBLE_QUOTES_WITH_NO_SPACE_BRACKET="{ port: \$MONGOLAB_PORT}"
+ENV SINGLE_QUOTES_INSIDE_DOUBLE="single 'quotes' work inside double quotes"
+ENV BACKTICKS_INSIDE_SINGLE="\`backticks\` work inside single quotes"
+ENV BACKTICKS_INSIDE_DOUBLE="\`backticks\` work inside double quotes"
+ENV BACKTICKS="backticks"
+ENV BACKTICKS_SPACED="    backticks    "
+ENV DOUBLE_QUOTES_INSIDE_BACKTICKS="double \"quotes\" work inside backticks"
+ENV SINGLE_QUOTES_INSIDE_BACKTICKS="single 'quotes' work inside backticks"
+ENV DOUBLE_AND_SINGLE_QUOTES_INSIDE_BACKTICKS="double \"quotes\" and single 'quotes' work inside backticks"
+ENV EXPAND_NEWLINES="expand\n\
+new\n\
+lines"
+ENV DONT_EXPAND_UNQUOTED="dontexpand\\nnewlines"
+ENV DONT_EXPAND_SQUOTED="dontexpand\\nnewlines"
+ENV INLINE_COMMENTS="inline comments"
+ENV INLINE_COMMENTS_SINGLE_QUOTES="inline comments outside of #singlequotes"
+ENV INLINE_COMMENTS_DOUBLE_QUOTES="inline comments outside of #doublequotes"
+ENV INLINE_COMMENTS_BACKTICKS="inline comments outside of #backticks"
+ENV INLINE_COMMENTS_SPACE="inline comments start with a"
+ENV EQUAL_SIGNS="equals=="
+ENV RETAIN_INNER_QUOTES="{\"foo\": \"bar\"}"
+ENV RETAIN_INNER_QUOTES_AS_STRING="{\"foo\": \"bar\"}"
+ENV RETAIN_INNER_QUOTES_AS_BACKTICKS="{\"foo\": \"bar's\"}"
+ENV TRIM_SPACE_FROM_UNQUOTED="some spaced out string"
+ENV USERNAME="therealnerdybeast@example.tld"
+ENV SPACED_KEY="parsed"
+# DOCKERFILE-X:END file="./inc/custom-envs.env" includedBy="issue3.dockerfile" includeType="include"
+# include custom args from external file
+# DOCKERFILE-X:START file="./inc/custom-labels.env" includedBy="issue3.dockerfile" includeType="include"
+LABEL orgopencontainersimagesource="https://github.com/example/repo"
+LABEL orgopencontainersimagerevision="0123456789"
+# DOCKERFILE-X:END file="./inc/custom-labels.env" includedBy="issue3.dockerfile" includeType="include"
+ENTRYPOINT [ "/bin/sh", "-c", "env" ]

--- a/test/features.js
+++ b/test/features.js
@@ -4,6 +4,9 @@ describe("INCLUDE", () => {
   it("include", async () => {
     await testFixture("include")
   })
+  it("include_envvars", async () => {
+    await testFixture("issue3")
+  })
 })
 
 describe("FROM", () => {

--- a/test/fixtures/inc/custom-args.env
+++ b/test/fixtures/inc/custom-args.env
@@ -1,0 +1,47 @@
+# Source: https://raw.githubusercontent.com/motdotla/dotenv/refs/heads/master/tests/.env.multiline
+BASIC=basic
+
+# previous line intentionally left blank
+AFTER_LINE=after_line
+EMPTY=
+SINGLE_QUOTES='single_quotes'
+SINGLE_QUOTES_SPACED='    single quotes    '
+DOUBLE_QUOTES="double_quotes"
+DOUBLE_QUOTES_SPACED="    double quotes    "
+EXPAND_NEWLINES="expand\nnew\nlines"
+DONT_EXPAND_UNQUOTED=dontexpand\nnewlines
+DONT_EXPAND_SQUOTED='dontexpand\nnewlines'
+# COMMENTS=work
+EQUAL_SIGNS=equals==
+RETAIN_INNER_QUOTES={"foo": "bar"}
+
+RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
+TRIM_SPACE_FROM_UNQUOTED=    some spaced out string
+USERNAME=therealnerdybeast@example.tld
+    SPACED_KEY = parsed
+
+MULTI_DOUBLE_QUOTED="THIS
+IS
+A
+MULTILINE
+STRING"
+
+MULTI_SINGLE_QUOTED='THIS
+IS
+A
+MULTILINE
+STRING'
+
+MULTI_BACKTICKED=`THIS
+IS
+A
+"MULTILINE'S"
+STRING`
+
+MULTI_PEM_DOUBLE_QUOTED="-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnNl1tL3QjKp3DZWM0T3u
+LgGJQwu9WqyzHKZ6WIA5T+7zPjO1L8l3S8k8YzBrfH4mqWOD1GBI8Yjq2L1ac3Y/
+bTdfHN8CmQr2iDJC0C6zY8YV93oZB3x0zC/LPbRYpF8f6OqX1lZj5vo2zJZy4fI/
+kKcI5jHYc8VJq+KCuRZrvn+3V+KuL9tF9v8ZgjF2PZbU+LsCy5Yqg1M8f5Jp5f6V
+u4QuUoobAgMBAAE=
+-----END PUBLIC KEY-----"

--- a/test/fixtures/inc/custom-envs.env
+++ b/test/fixtures/inc/custom-envs.env
@@ -1,0 +1,40 @@
+# Source: https://raw.githubusercontent.com/motdotla/dotenv/refs/heads/master/tests/.env
+
+BASIC=basic
+
+# previous line intentionally left blank
+AFTER_LINE=after_line
+EMPTY=
+EMPTY_SINGLE_QUOTES=''
+EMPTY_DOUBLE_QUOTES=""
+EMPTY_BACKTICKS=``
+SINGLE_QUOTES='single_quotes'
+SINGLE_QUOTES_SPACED='    single quotes    '
+DOUBLE_QUOTES="double_quotes"
+DOUBLE_QUOTES_SPACED="    double quotes    "
+DOUBLE_QUOTES_INSIDE_SINGLE='double "quotes" work inside single quotes'
+DOUBLE_QUOTES_WITH_NO_SPACE_BRACKET="{ port: $MONGOLAB_PORT}"
+SINGLE_QUOTES_INSIDE_DOUBLE="single 'quotes' work inside double quotes"
+BACKTICKS_INSIDE_SINGLE='`backticks` work inside single quotes'
+BACKTICKS_INSIDE_DOUBLE="`backticks` work inside double quotes"
+BACKTICKS=`backticks`
+BACKTICKS_SPACED=`    backticks    `
+DOUBLE_QUOTES_INSIDE_BACKTICKS=`double "quotes" work inside backticks`
+SINGLE_QUOTES_INSIDE_BACKTICKS=`single 'quotes' work inside backticks`
+DOUBLE_AND_SINGLE_QUOTES_INSIDE_BACKTICKS=`double "quotes" and single 'quotes' work inside backticks`
+EXPAND_NEWLINES="expand\nnew\nlines"
+DONT_EXPAND_UNQUOTED=dontexpand\nnewlines
+DONT_EXPAND_SQUOTED='dontexpand\nnewlines'
+# COMMENTS=work
+INLINE_COMMENTS=inline comments # work #very #well
+INLINE_COMMENTS_SINGLE_QUOTES='inline comments outside of #singlequotes' # work
+INLINE_COMMENTS_DOUBLE_QUOTES="inline comments outside of #doublequotes" # work
+INLINE_COMMENTS_BACKTICKS=`inline comments outside of #backticks` # work
+INLINE_COMMENTS_SPACE=inline comments start with a#number sign. no space required.
+EQUAL_SIGNS=equals==
+RETAIN_INNER_QUOTES={"foo": "bar"}
+RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
+RETAIN_INNER_QUOTES_AS_BACKTICKS=`{"foo": "bar's"}`
+TRIM_SPACE_FROM_UNQUOTED=    some spaced out string
+USERNAME=therealnerdybeast@example.tld
+    SPACED_KEY = parsed

--- a/test/fixtures/inc/custom-labels.env
+++ b/test/fixtures/inc/custom-labels.env
@@ -1,0 +1,2 @@
+org.opencontainers.image.source="https://github.com/example/repo"
+org.opencontainers.image.revision=0123456789

--- a/test/fixtures/issue3.dockerfile
+++ b/test/fixtures/issue3.dockerfile
@@ -1,0 +1,15 @@
+# syntax=devthefuture/dockerfile-x
+# See https://codeberg.org/devthefuture/dockerfile-x/issues/3
+
+FROM busybox
+
+# include custom args from external file
+INCLUDE_ARGS ./inc/custom-args.env
+
+# include custom envvars from external file
+INCLUDE_ENVS ./inc/custom-envs.env
+
+# include custom args from external file
+INCLUDE_LABELS ./inc/custom-labels.env
+
+ENTRYPOINT [ "/bin/sh", "-c", "env" ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1431,6 +1431,7 @@ __metadata:
     chai: ^4.3.8
     commander: ^11.0.0
     docker-file-parser: ^1.0.7
+    dotenv: ^17.2.1
     eslint: ^8.48.0
     eslint-config-prettier: ^9.0.0
     eslint-plugin-mocha: ^10.1.0
@@ -1463,6 +1464,13 @@ __metadata:
   dependencies:
     is-obj: ^2.0.0
   checksum: d5775790093c234ef4bfd5fbe40884ff7e6c87573e5339432870616331189f7f5d86575c5b5af2dcf0f61172990f4f734d07844b1f23482fff09e3c4bead05ea
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^17.2.1":
+  version: 17.2.1
+  resolution: "dotenv@npm:17.2.1"
+  checksum: 2a3842a5451eb64f41cd11bd30d4d9d83941058f952f5e3adc3ca470d381e46ed8acbb0c0e3059da9725df91b42796987fa1deb032fafac992c37b94870ef085
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request implements [a request](https://codeberg.org/devthefuture/dockerfile-x/issues/3) to include a `.env` file and convert it into `ARG` instructions inside the Dockerfile. It also extends support to `ENV` and `LABEL` instructions.

The README.md has been updated (needs @devthejo to review before release).

Fixtures have been added and tested.